### PR TITLE
Create initial dashboard test

### DIFF
--- a/src/main/java/pages/DashboardPage.java
+++ b/src/main/java/pages/DashboardPage.java
@@ -8,6 +8,10 @@ public class DashboardPage extends BasePage {
     private By headerBreadcrumb = By.cssSelector(".oxd-topbar-header-breadcrumb-module");
     private By userDropdown = By.cssSelector(".oxd-userdropdown");
     private By logoutLink = By.linkText("Logout");
+    private By employeeLeaveCogIcon = By.cssSelector(".orangehrm-leave-card-icon");
+    private By configModalSwitchToggle = By.cssSelector(".orangehrm-dialog-modal .oxd-switch-input");
+    private By configModalSaveButton = By.cssSelector(".orangehrm-dialog-modal button[type=submit]");
+    private By successNotification = By.cssSelector("#oxd-toaster_1 .oxd-toast--success");
 
     public DashboardPage(WebDriver driver) {
         super(driver);
@@ -24,5 +28,21 @@ public class DashboardPage extends BasePage {
     public void logout() {
         getElement(userDropdown).click();
         getElement(logoutLink).click();
+    }
+
+    public void clickEmployeeLeavingCogIcon() {
+        clickElement(employeeLeaveCogIcon);
+    }
+
+    public void clickConfigModalSwitchToggle() {
+        clickElement(configModalSwitchToggle);
+    }
+
+    public void clickConfigModalSaveButton() {
+        clickElement(configModalSaveButton);
+    }
+
+    public boolean isSuccessNotificationDisplayed() {
+        return getElement(successNotification).isDisplayed();
     }
 }

--- a/src/test/java/dashboard/DashboardTests.java
+++ b/src/test/java/dashboard/DashboardTests.java
@@ -1,0 +1,32 @@
+package dashboard;
+
+import base.BaseTests;
+import org.testng.annotations.Test;
+import pages.DashboardPage;
+
+import static org.testng.Assert.assertTrue;
+
+public class DashboardTests extends BaseTests {
+
+    @Test
+    public void testEmployeeLeaveConfigChange() {
+        loginPage.enterCredentials("admin", "admin123");
+        DashboardPage dashboardPage = loginPage.clickLoginButton();
+
+        dashboardPage.clickEmployeeLeavingCogIcon();
+        dashboardPage.clickConfigModalSwitchToggle();
+        dashboardPage.clickConfigModalSaveButton();
+
+        assertTrue(dashboardPage.isSuccessNotificationDisplayed(), "Success notification not displayed");
+    }
+
+    @Test
+    public void testHelpButtonOpensLinkInNewTab() {
+
+    }
+
+    @Test
+    public void testEmployeeByDeptChartShowsTooltipOnHover() {
+
+    }
+}


### PR DESCRIPTION
Initial dashboard test created to interact with employee leave modal and confirm success message is displayed when employee leave config is changed. Locators and methods added to DashboardPage object. Empty test methods added for subsequent dashboard tests I plan to add.