### PR TITLE
Add test clicking Buzz Post navigates to Buzz Page

### DIFF
--- a/src/main/java/pages/BasePage.java
+++ b/src/main/java/pages/BasePage.java
@@ -5,6 +5,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.time.Duration;
+import java.util.List;
 
 public class BasePage {
 
@@ -18,6 +19,10 @@ public class BasePage {
 
     protected WebElement getElement(By locator) {
         return wait.until(ExpectedConditions.visibilityOfElementLocated(locator));
+    }
+
+    protected List<WebElement> getElements(By locator) {
+        return wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(locator));
     }
 
     protected String getText(By locator) {
@@ -45,7 +50,6 @@ public class BasePage {
     public int getTabCount() {
         return driver.getWindowHandles().size();
     }
-
 
     /**
      * Switches to the first tab that isn't the current tab

--- a/src/main/java/pages/BuzzPage.java
+++ b/src/main/java/pages/BuzzPage.java
@@ -1,0 +1,17 @@
+package pages;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+public class BuzzPage extends BasePage {
+
+    By newsfeedTitle = By.cssSelector(".orangehrm-buzz-newsfeed-title");
+
+    public BuzzPage(WebDriver driver) {
+        super(driver);
+    }
+
+    public boolean isNewsfeedTitleVisible() {
+        return getElement(newsfeedTitle).isDisplayed();
+    }
+}

--- a/src/main/java/pages/DashboardPage.java
+++ b/src/main/java/pages/DashboardPage.java
@@ -2,6 +2,7 @@ package pages;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 public class DashboardPage extends BasePage {
 
@@ -13,6 +14,7 @@ public class DashboardPage extends BasePage {
     private By configModalSwitchToggle = By.cssSelector(".orangehrm-dialog-modal .oxd-switch-input");
     private By configModalSaveButton = By.cssSelector(".orangehrm-dialog-modal button[type=submit]");
     private By successNotification = By.cssSelector("#oxd-toaster_1 .oxd-toast--success");
+    private By buzzPosts = By.cssSelector(".orangehrm-buzz-widget-header-text");
 
     public DashboardPage(WebDriver driver) {
         super(driver);
@@ -60,5 +62,16 @@ public class DashboardPage extends BasePage {
         }
 
         return null;
+    }
+
+    /**
+     * Clicks the desired 'Buzz Post' in the Dashboard feed
+     * @param index starts at 1
+     * @return a new BuzzPage object
+     */
+    public BuzzPage clickBuzzPost(int index) {
+        WebElement buzzPost = getElements(buzzPosts).get(index - 1);
+        buzzPost.click();
+        return new BuzzPage(driver);
     }
 }

--- a/src/test/java/dashboard/DashboardTests.java
+++ b/src/test/java/dashboard/DashboardTests.java
@@ -4,6 +4,7 @@ import base.BaseTests;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import pages.BuzzPage;
 import pages.DashboardPage;
 import pages.HelpPage;
 
@@ -42,8 +43,9 @@ public class DashboardTests extends BaseTests {
         dashboardPage = helpPage.switchToDashboardPageTab();
     }
 
-//    @Test
-//    public void testEmployeeByDeptChartShowsTooltipOnHover() {
-//
-//    }
+    @Test
+    public void testClickingBuzzPostNavigatesToBuzzPage() {
+        BuzzPage buzzPage = dashboardPage.clickBuzzPost(1);
+        assertTrue(buzzPage.isNewsfeedTitleVisible(), "Newsfeed is not displayed");
+    }
 }


### PR DESCRIPTION
New dashboard test added to confirm that clicking the first buzz post shown on the dashboard page takes you to the Buzz Page within the app. BuzzPage page object class and DashboardPage methods add to assist with this.