### PR TITLE
Move login/logout methods to their own test class

### DIFF
--- a/src/test/java/base/BaseTests_LoginLogout.java
+++ b/src/test/java/base/BaseTests_LoginLogout.java
@@ -1,0 +1,21 @@
+package base;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import pages.DashboardPage;
+
+public class BaseTests_LoginLogout extends BaseTests {
+
+    protected DashboardPage dashboardPage;
+
+    @BeforeMethod
+    public void login() {
+        this.loginPage.enterCredentials("admin", "admin123");
+        this.dashboardPage = loginPage.clickLoginButton();
+    }
+
+    @AfterMethod
+    public void logout() {
+        dashboardPage.logout();
+    }
+}

--- a/src/test/java/dashboard/DashboardTests.java
+++ b/src/test/java/dashboard/DashboardTests.java
@@ -1,6 +1,7 @@
 package dashboard;
 
 import base.BaseTests;
+import base.BaseTests_LoginLogout;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -11,20 +12,7 @@ import pages.HelpPage;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-public class DashboardTests extends BaseTests {
-
-    private DashboardPage dashboardPage;
-
-    @BeforeMethod
-    public void login() {
-        this.loginPage.enterCredentials("admin", "admin123");
-        this.dashboardPage = loginPage.clickLoginButton();
-    }
-
-    @AfterMethod
-    public void logout() {
-        dashboardPage.logout();
-    }
+public class DashboardTests extends BaseTests_LoginLogout {
 
     @Test
     public void testEmployeeLeaveConfigChange() {

--- a/src/test/java/myInfo/PersonalDetailsTests.java
+++ b/src/test/java/myInfo/PersonalDetailsTests.java
@@ -1,6 +1,7 @@
 package myInfo;
 
 import base.BaseTests;
+import base.BaseTests_LoginLogout;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -9,20 +10,7 @@ import pages.PersonalDetailsPage;
 
 import static org.testng.Assert.assertEquals;
 
-public class PersonalDetailsTests extends BaseTests {
-
-    private DashboardPage dashboardPage;
-
-    @BeforeMethod
-    public void login() {
-        this.loginPage.enterCredentials("admin", "admin123");
-        this.dashboardPage = loginPage.clickLoginButton();
-    }
-
-    @AfterMethod
-    public void logout() {
-        dashboardPage.logout();
-    }
+public class PersonalDetailsTests extends BaseTests_LoginLogout {
 
     @Test
     public void testNationalitySelection() {


### PR DESCRIPTION
Login (BeforeMethod) and Login (AfterMethod) methods are repeated in all tests that are not LoginTests. BaseTests_LoginLogout inherits from BaseTests and the non-LoginTests will inherit from BaseTests_LoginLogout. Whereas LoginTests will continue to inherit from BaseTests since we do not want login and logout methods to be performed before and after these tests.