### PR TITLE
Add tests for deletion of buzz posts

### DIFF
--- a/src/main/java/pages/BasePage.java
+++ b/src/main/java/pages/BasePage.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 public class BasePage {
 
@@ -68,5 +69,18 @@ public class BasePage {
                 driver.switchTo().window(windowHandle);
             }
         }
+    }
+
+    protected void clickElementFromListByText(By locator, String text) {
+        List<WebElement> elements = getElements(locator);
+
+        for (WebElement element : elements) {
+            if (element.getText().contains(text)) {
+                element.click();
+                return;
+            }
+        }
+
+        throw new NoSuchElementException("Element with the text " + text + " was not found");
     }
 }

--- a/src/main/java/pages/BuzzPage.java
+++ b/src/main/java/pages/BuzzPage.java
@@ -19,7 +19,8 @@ public class BuzzPage extends BasePage {
     By buzzPostConfigButtons = By.cssSelector(".orangehrm-buzz-post-header-config .oxd-icon-button");
     By buzzPostConfigMenuItems = By.cssSelector(".orangehrm-buzz-post-header-config-item");
     By buzzPostEditTextArea = By.cssSelector(".orangehrm-buzz-post-modal-header-text .oxd-buzz-post-input");
-    By buzzPostModalPostButton = By.cssSelector(".orangehrm-dialog-modal .oxd-button");
+    By buzzPostEditModalPostButton = By.cssSelector(".orangehrm-dialog-modal .oxd-button");
+    By deleteModalButtons = By.cssSelector(".orangehrm-dialog-popup .oxd-button");
 
     public BuzzPage(WebDriver driver) {
         super(driver);
@@ -74,9 +75,19 @@ public class BuzzPage extends BasePage {
     public void editBuzzPost(int index, String text) {
         if (isAtLeastOneBuzzPostPresent()) {
             clickBuzzPostConfigButton(index - 1);
-            clickBuzzPostConfigMenuItem("Edit");
+            clickElementFromListByText(buzzPostConfigMenuItems, "Edit Post");
             setEditPostText(text);
             clickModalPostButton();
+        } else {
+            throw new NoSuchElementException("No buzz posts are present");
+        }
+    }
+
+    public void deleteBuzzPost(int index, String modalOption) {
+        if (isAtLeastOneBuzzPostPresent()) {
+            clickBuzzPostConfigButton(index - 1);
+            clickElementFromListByText(buzzPostConfigMenuItems, "Delete Post");
+            clickElementFromListByText(deleteModalButtons, modalOption);
         } else {
             throw new NoSuchElementException("No buzz posts are present");
         }
@@ -91,29 +102,11 @@ public class BuzzPage extends BasePage {
         configButton.click();
     }
 
-    public void clickBuzzPostConfigMenuItem(String menuItem) {
-        List<WebElement> configMenuItems = getElements(buzzPostConfigMenuItems);
-
-        for (WebElement configMenuItem : configMenuItems) {
-            if (configMenuItem.getText().contains(menuItem)) {
-                configMenuItem.click();
-                return;
-            }
-        }
-
-        throw new NoSuchElementException("Menu item with the text " + menuItem + " was not found");
-    }
-
     public void setEditPostText(String text) {
         setText(buzzPostEditTextArea, text);
     }
 
     public void clickModalPostButton() {
-        clickElement(buzzPostModalPostButton);
-        getElement(buzzPostEditTextArea).sendKeys(text);
-    }
-
-    public void clickModalPostButton() {
-        getElement(buzzPostModalPostButton).click();
+        clickElement(buzzPostEditModalPostButton);
     }
 }

--- a/src/test/java/buzz/BuzzTests.java
+++ b/src/test/java/buzz/BuzzTests.java
@@ -4,8 +4,7 @@ import base.BaseTests_LoginLogout;
 import org.testng.annotations.Test;
 import pages.BuzzPage;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 import static utils.RandomVariables.getRandomString;
 
 
@@ -37,7 +36,7 @@ public class BuzzTests extends BaseTests_LoginLogout {
         String newText = getRandomString();
         buzzPage.editBuzzPost(1, newText);
 
-        assertTrue(buzzPage.isSuccessNotificationDisplayed(), "Post not successful");
+        assertTrue(buzzPage.isSuccessNotificationDisplayed(), "Edit post not successful");
     }
 
     @Test
@@ -46,11 +45,47 @@ public class BuzzTests extends BaseTests_LoginLogout {
         buzzPage.createBuzzPost(getRandomString());
         buzzPage.clickBuzzPostNavLink();
 
-        int editedPost = 1;
+        int firstPost = 1;
         String newText = getRandomString();
-        buzzPage.editBuzzPost(editedPost, newText);
+        buzzPage.editBuzzPost(firstPost, newText);
 
-        assertTrue(buzzPage.isTextPresentInBuzzPost(editedPost, newText),
-                "Edited buzz post does not contain new text");
+        assertTrue(buzzPage.isTextPresentInBuzzPost(firstPost, newText),
+                "Edited post does not contain new text");
+    }
+
+    @Test
+    public void testDeletionOfNewBuzzPostIsSuccessful() {
+        BuzzPage buzzPage = dashboardPage.clickBuzzPost(1);
+        buzzPage.createBuzzPost(getRandomString());
+        buzzPage.clickBuzzPostNavLink();
+
+        buzzPage.deleteBuzzPost(1, "Delete");
+        assertTrue(buzzPage.isSuccessNotificationDisplayed(), "Delete post not successful");
+    }
+
+    @Test
+    public void testDeletedNewPostIsNotPresentInFeed() {
+        BuzzPage buzzPage = dashboardPage.clickBuzzPost(1);
+        String text = getRandomString();
+        buzzPage.createBuzzPost(text);
+        buzzPage.clickBuzzPostNavLink();
+
+        int firstPost = 1;
+        buzzPage.deleteBuzzPost(firstPost, "Delete");
+        buzzPage.clickBuzzPostNavLink();
+        assertFalse(buzzPage.isTextPresentInBuzzPost(firstPost, text) , "Deleted post is still present");
+    }
+
+    @Test
+    public void testCancelDeletionKeepsPostInFeed() {
+        BuzzPage buzzPage = dashboardPage.clickBuzzPost(1);
+        String text = getRandomString();
+        buzzPage.createBuzzPost(text);
+        buzzPage.clickBuzzPostNavLink();
+
+        int firstPost = 1;
+        buzzPage.deleteBuzzPost(1, "Cancel");
+        buzzPage.clickBuzzPostNavLink();
+        assertTrue(buzzPage.isTextPresentInBuzzPost(firstPost, text), "Post is not present");
     }
 }


### PR DESCRIPTION
Working tests for successful deletion and checking if a post is present or not depending on which option you select in the delete pop-up (Cancel/Delete). Move method for clicking an element based on the element's text to the BasePage for improved reusability.